### PR TITLE
Adding Redux-Persist for LocalStorage with Redux Store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12635,6 +12635,11 @@
         "deep-diff": "^0.3.5"
       }
     },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-scripts": "^3.4.0",
     "redux": "^4.0.4",
     "redux-logger": "^3.0.6",
+    "redux-persist": "^6.0.0",
     "reselect": "^4.0.0"
   },
   "scripts": {

--- a/src/components/directory/directory.component.jsx
+++ b/src/components/directory/directory.component.jsx
@@ -1,63 +1,27 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
+
+import { selectDirectorySections } from '../../redux/directory/directory.selectors';
+
 import MenuItem from '../menu-item/menu-item.component'
 import './directory.styles.scss';
 
-class Directory extends Component {
-    constructor() {
-        super();
-        this.state = {
-            sections: [
-                {
-                    title: 'hats',
-                    imageUrl: 'https://i.ibb.co/cvpntL1/hats.png',
-                    id: 1,
-                    linkUrl: 'shop/hats'
-                },
-                {
-                    title: 'jackets',
-                    imageUrl: 'https://i.ibb.co/px2tCc3/jackets.png',
-                    id: 2,
-                    linkUrl: 'shop/jackets'
-                },
-                {
-                    title: 'sneakers',
-                    imageUrl: 'https://i.ibb.co/0jqHpnp/sneakers.png',
-                    id: 3,
-                    linkUrl: 'shop/sneakers'
-                },
-                {
-                    title: 'womens',
-                    imageUrl: 'https://i.ibb.co/GCCdy8t/womens.png',
-                    size: 'large',
-                    id: 4,
-                    linkUrl: 'shop/womens'
-                },
-                {
-                    title: 'mens',
-                    imageUrl: 'https://i.ibb.co/R70vBrQ/men.png',
-                    size: 'large',
-                    id: 5,
-                    linkUrl: 'shop/mens'
-                }
-            ]
+const Directory = ({ sections }) => (
+    <div className="directory-menu">
+        {
+            this.state.sections.map(({ id, ...otherSectionProps }, index) => (
+                <MenuItem
+                    key={id}
+                    {...otherSectionProps}
+                />
+            )
+            )
         }
-    }
+    </div>
+);
 
-    render() {
-        return (
-            <div className="directory-menu">
-                {
-                    this.state.sections.map(({ id, ...otherSectionProps }, index) => (
-                        <MenuItem
-                            key={id}
-                            {...otherSectionProps}
-                        />
-                    )
-                    )
-                }
-            </div>
-        )
-    }
-}
-
-export default Directory;
+const mapStateToProps = createStructuredSelector({
+    sections: selectDirectorySections,
+})
+export default connect(mapStateToProps)(Directory);

--- a/src/index.js
+++ b/src/index.js
@@ -2,16 +2,21 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
+
+
 
 import './index.css';
 import App from './App';
 
-import store from './redux/store';
+import {store, persistor} from './redux/store';
 
 ReactDOM.render(
 	<Provider store={store}>
 		<BrowserRouter>
-			<App />
+			<PersistGate persistor={persistor}>
+				<App />
+			</PersistGate>
 		</BrowserRouter>
 	</Provider>,
 	document.getElementById('root')

--- a/src/redux/directory/directory.reducer.js
+++ b/src/redux/directory/directory.reducer.js
@@ -1,0 +1,44 @@
+const INITIAL_STATE = {
+    sections: [{
+            title: 'hats',
+            imageUrl: 'https://i.ibb.co/cvpntL1/hats.png',
+            id: 1,
+            linkUrl: 'shop/hats'
+        },
+        {
+            title: 'jackets',
+            imageUrl: 'https://i.ibb.co/px2tCc3/jackets.png',
+            id: 2,
+            linkUrl: 'shop/jackets'
+        },
+        {
+            title: 'sneakers',
+            imageUrl: 'https://i.ibb.co/0jqHpnp/sneakers.png',
+            id: 3,
+            linkUrl: 'shop/sneakers'
+        },
+        {
+            title: 'womens',
+            imageUrl: 'https://i.ibb.co/GCCdy8t/womens.png',
+            size: 'large',
+            id: 4,
+            linkUrl: 'shop/womens'
+        },
+        {
+            title: 'mens',
+            imageUrl: 'https://i.ibb.co/R70vBrQ/men.png',
+            size: 'large',
+            id: 5,
+            linkUrl: 'shop/mens'
+        }
+    ]
+}
+
+const directoryReducer = (state = INITIAL_STATE, action) => {
+    switch (action.type) {
+        default:
+            return state;
+    }
+}
+
+export default directoryReducer;

--- a/src/redux/directory/directory.selectors.js
+++ b/src/redux/directory/directory.selectors.js
@@ -1,0 +1,10 @@
+import {
+    createSelector
+} from 'reselect';
+
+const selectDirectory = state => state.directory;
+
+export const selectDirectorySections = createSelector(
+    [selectDirectory],
+    directory => directory.sections
+);

--- a/src/redux/root-reducer.js
+++ b/src/redux/root-reducer.js
@@ -1,9 +1,27 @@
-import { combineReducers } from 'redux';
+import {
+    combineReducers
+} from 'redux';
+import {
+    persistReducer
+} from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 
 import userReducer from './user/user.reducer';
 import cartReducer from './cart/cart.reducer'
+import directoryReducer from './directory/directory.reducer';
 
-export default combineReducers({
+const persistConfig = {
+    key: 'root',
+    storage,
+    whitelist: [
+        'cart'
+    ]
+};
+
+const rootReducer = combineReducers({
     user: userReducer,
     cart: cartReducer,
+    directory: directoryReducer,
 })
+
+export default persistReducer(persistConfig, rootReducer);

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,10 +1,20 @@
-import { createStore, applyMiddleware } from 'redux';
+import {
+    createStore,
+    applyMiddleware
+} from 'redux';
 import logger from 'redux-logger';
+import {
+    persistStore
+} from 'redux-persist';
 
 import rootReducer from './root-reducer';
 
 const middlewares = [logger];
 
 const store = createStore(rootReducer, applyMiddleware(...middlewares));
+const persistor = persistStore(store);
 
-export default store;
+export {
+    store,
+    persistor
+};


### PR DESCRIPTION
This PR:
- adds the `redux-persist` library to save slices of state to localStorage. To ensure cart information is not lost between refreshes, the cart slice of store is now being saved to localStorage. 
- removes hardcoded state from the directory component and adds it to the redux store